### PR TITLE
Add search filters to admin orders and sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Sales Channel Pro es una aplicación web diseñada para gestionar un canal de ve
     *   Solicitud de reposición de stock de productos.
 *   **Panel de Administración (Requiere Autenticación):**
     *   Visualización y gestión del estado de pedidos de clientes (incluyendo estado de pago).
-    *   Visualización de ventas de vendedores.
+*   Visualización de ventas de vendedores.
+*   Búsqueda y filtrado en pedidos de clientes y ventas de vendedores para agilizar la revisión.
     *   Gestión de solicitudes de productos de vendedores (aprobación/rechazo/surtido).
     *   Gestión de Productos (CRUD):
         *   Agregar nuevos productos al catálogo.

--- a/localization.ts
+++ b/localization.ts
@@ -134,11 +134,14 @@ Tu pedido será procesado una vez que se confirme el pago.`,
   adminWelcome: 'Bienvenido, {adminName}',
   customerOrders: 'Pedidos de Clientes',
   sellerSales: 'Ventas de Vendedores',
+  searchOrdersPlaceholder: 'Buscar pedidos...',
+  searchSalesPlaceholder: 'Buscar ventas...',
   productRequests: 'Solicitudes de Productos',
   salesSummaryAI: 'Resumen de Ventas (IA)',
   noCustomerOrders: 'Aún no hay pedidos de clientes.',
   customerLabel: 'Cliente:', // Changed
   noSalesRecords: 'Aún no hay registros de ventas.',
+  noResultsFound: 'No se encontraron resultados.',
   saleIdLabel: 'ID de Venta:', // Changed
   sourceLabel: 'Fuente:', // Changed
   itemsSold: 'Artículos Vendidos:',

--- a/localization.ts
+++ b/localization.ts
@@ -56,6 +56,7 @@ export const translations = {
   storeName: 'Nombre de la Tienda',
   viewCart: 'Ver Carrito',
   searchProductsPlaceholder: 'Buscar productos...',
+  searchProductRequestsPlaceholder: 'Buscar solicitudes por ID, vendedor, producto...',
   shoppingCartTitle: 'Carrito de Compras',
   cartEmpty: 'Tu carrito está vacío.',
   decreaseQuantity: 'Disminuir cantidad',

--- a/views/AdminView.tsx
+++ b/views/AdminView.tsx
@@ -120,6 +120,33 @@ const AdminView: React.FC<AdminViewProps> = ({
   const [isDeleteSellerConfirmModalOpen, setIsDeleteSellerConfirmModalOpen] = useState(false);
   const [deletingSellerInfo, setDeletingSellerInfo] = useState<{ id: string, name: string, username: string } | null>(null);
 
+  const [orderSearchTerm, setOrderSearchTerm] = useState('');
+  const [salesSearchTerm, setSalesSearchTerm] = useState('');
+  const [requestSearchTerm, setRequestSearchTerm] = useState('');
+
+  const filteredProductRequests = useMemo(() => {
+    if (!productRequests) return []; // Guard clause for undefined productRequests
+    const term = requestSearchTerm.toLowerCase();
+    return productRequests.filter(req => {
+      const id = typeof req.id === 'string' ? req.id.toLowerCase() : '';
+      const sellerId = typeof req.sellerId === 'string' ? req.sellerId.toLowerCase() : '';
+      const sellerName = req.requestedBy?.name?.toLowerCase() || '';
+      const productName = req.product?.name?.toLowerCase() || '';
+      const quantity = String(req.quantityRequested);
+      const createdAtStr = typeof req.createdAt === 'string' ? req.createdAt.toLowerCase() : '';
+      const notes = req.notes?.toLowerCase() || '';
+      return (
+        (id && id.includes(term)) ||
+        (sellerId && sellerId.includes(term)) ||
+        sellerName.includes(term) ||
+        productName.includes(term) ||
+        quantity.includes(term) ||
+        (createdAtStr && createdAtStr.includes(term)) ||
+        notes.includes(term)
+      );
+    });
+  }, [productRequests, requestSearchTerm]);
+
 
   const handleNewProductInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -277,7 +304,7 @@ const AdminView: React.FC<AdminViewProps> = ({
   
   const cardBaseClasses = "p-5 bg-surface rounded-xl shadow-lg border border-borderLight";
   const selectClasses = "p-2 border border-borderLight rounded-lg text-sm focus:ring-2 focus:ring-secondary focus:border-secondary text-textPrimary bg-white";
-  const inputClasses = "mt-1 block w-full px-3 py-2 border border-borderLight rounded-md shadow-sm focus:outline-none focus:ring-secondary focus:border-secondary sm:text-sm bg-white text-textPrimary placeholder-textSecondary";
+  const inputClasses = "w-full p-3 border border-borderLight rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow shadow-sm placeholder-textSecondary text-textPrimary bg-white";
   const labelClasses = "block text-sm font-medium text-textSecondary";
   const primaryButtonClasses = "px-6 py-3 bg-secondary hover:bg-secondary-dark text-textOnSecondary font-semibold rounded-lg shadow-md hover:shadow-lg transition-all transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-secondary-light focus:ring-opacity-75 disabled:bg-slate-400 disabled:shadow-none disabled:scale-100 disabled:cursor-not-allowed";
   const secondaryButtonClasses = "px-4 py-2 text-sm font-medium text-textPrimary bg-slate-100 hover:bg-slate-200 rounded-lg border border-borderLight shadow-sm hover:shadow-md transition-colors disabled:bg-slate-300";
@@ -466,7 +493,7 @@ const AdminView: React.FC<AdminViewProps> = ({
             placeholder={t('searchProductRequestsPlaceholder' as TranslationKey)}
             value={requestSearchTerm}
             onChange={(e) => setRequestSearchTerm(e.target.value)}
-            className="w-full p-3 border border-borderLight rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow shadow-sm"
+            className={inputClasses}
           />
         </div>
         {filteredProductRequests && filteredProductRequests.length > 0 ? (

--- a/views/AdminView.tsx
+++ b/views/AdminView.tsx
@@ -293,7 +293,7 @@ const AdminView: React.FC<AdminViewProps> = ({
       const quantities = order.items.reduce((sum, i) => sum + i.quantity, 0).toString();
       const dateStr = new Date(order.createdAt).toLocaleDateString('es-MX').toLowerCase();
       return (
-        order.id.toLowerCase().includes(term) ||
+        (typeof order.id === 'string' ? order.id.toLowerCase() : '').includes(term) ||
         order.customerName.toLowerCase().includes(term) ||
         order.customerEmail.toLowerCase().includes(term) ||
         (order.userId && String(order.userId).includes(term)) ||

--- a/views/AdminView.tsx
+++ b/views/AdminView.tsx
@@ -124,12 +124,12 @@ const AdminView: React.FC<AdminViewProps> = ({
   const filteredProductRequests = useMemo(() => {
     const term = requestSearchTerm.toLowerCase();
     return productRequests.filter(req => {
-      const id = req.id?.toLowerCase();
-      const sellerId = req.sellerId?.toLowerCase();
+      const id = typeof req.id === 'string' ? req.id.toLowerCase() : '';
+      const sellerId = typeof req.sellerId === 'string' ? req.sellerId.toLowerCase() : '';
       const sellerName = req.requestedBy?.name?.toLowerCase() || '';
       const productName = req.product?.name?.toLowerCase() || '';
       const quantity = String(req.quantityRequested);
-      const date = req.createdAt?.toLowerCase();
+      const createdAtStr = typeof req.createdAt === 'string' ? req.createdAt.toLowerCase() : '';
       const notes = req.notes?.toLowerCase() || '';
       return (
         (id && id.includes(term)) ||
@@ -137,7 +137,7 @@ const AdminView: React.FC<AdminViewProps> = ({
         sellerName.includes(term) ||
         productName.includes(term) ||
         quantity.includes(term) ||
-        (date && date.includes(term)) ||
+        (createdAtStr && createdAtStr.includes(term)) ||
         notes.includes(term)
       );
     });


### PR DESCRIPTION
## Summary
- add translation keys for admin search placeholders and no results message
- implement order and sale filtering with search bars in AdminView
- remove debugging logs
- document search functionality in README

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684112ebf6748331bfce43aa3221a085